### PR TITLE
pass ellipsis to scale_x_continuous

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -441,15 +441,17 @@ trans_seq_rev<- function(unit = c("Mb", "kb", "bp")){
     function(x) {paste(x, unit)}
 }
 
-scale_x_sequnit <- function(unit = c("Mb", "kb", "bp"), append = NULL){
+scale_x_sequnit <- function(unit = c("Mb", "kb", "bp"), append = NULL, ...){
   unit <- match.arg(unit)
   if(is.null(append)){
       scale_x_continuous(breaks = trans_breaks(trans_seq(unit),
                              trans_seq_rev(unit)),
-                         labels = trans_format(trans_seq_format(unit), math_format(.x)))
-  }else{
+                         labels = trans_format(trans_seq_format(unit), math_format(.x)), 
+                         ...)
+  } else {
       stopifnot(is.character(append))
-      scale_x_continuous(labels = trans_format(.append_unit(append), math_format(.x)))
+      scale_x_continuous(labels = trans_format(.append_unit(append), math_format(.x)), 
+                        ...)
   }
 }
 


### PR DESCRIPTION
Hi, 

(This is a really minor pull request.)
I found that I needed to manually make some tweaks to `scale_x_sequnit`, like setting limits.
Just passing the ellipsis to `ggplot2::scale_x_continuous` does the job.

This edit was tested locally; it works, unless you explicitely pass `breaks` to `scale_x_sequnit`.
Do you think it need to be taken care of?

thanks for ggbio; it is pure gold.