### PR TITLE
Update gha checkout and cache versions

### DIFF
--- a/.github/workflows/R-CMD-check-and-coverage.yaml
+++ b/.github/workflows/R-CMD-check-and-coverage.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Query dependencies
         run: |
@@ -27,7 +27,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /usr/local/lib/R/site-library
           key: ${{ runner.os }}-r-1-${{ hashFiles('.github/depends.Rds') }}


### PR DESCRIPTION
Github actions `actions/cache: v2` is deprecated making the gha workflow fail on the master branch. This pr updates cache version to 4 and checkout to version 5.