### PR TITLE
Fix github action workflow 

### DIFF
--- a/.github/workflows/R-CMD-check-and-coverage.yaml
+++ b/.github/workflows/R-CMD-check-and-coverage.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup R from r-lib
         uses: r-lib/actions/setup-r@v2
 
-      - name: Install system dependencies 
+      - name: Install system dependencies from r-lib
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |

--- a/.github/workflows/R-CMD-check-and-coverage.yaml
+++ b/.github/workflows/R-CMD-check-and-coverage.yaml
@@ -33,16 +33,29 @@ jobs:
           key: ${{ runner.os }}-r-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-r-1-
 
-      - name: Install system dependencies
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
+      - name: Setup R from r-lib
+        uses: r-lib/actions/setup-r@v2
+
+      - name: Install system dependencies 
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::rcmdcheck
+            any::BiocCheck
+            any::covr
+            local::.
+          needs: |
+            coverage
+            check
+
+      - name: Install LaTeX
+        if: runner.os == 'Linux'
         run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          latexreq="texlive-latex-base texlive-fonts-recommended texlive-fonts-extra"
-          sysreqs="$sysreqs $latexreq"
-          echo $sysreqs
-          sudo -s eval "$sysreqs"
+          sudo apt-get update -y
+          sudo apt-get install -y \
+            texlive-latex-base \
+            texlive-fonts-recommended \
+            texlive-fonts-extra
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/R-CMD-check-and-coverage.yaml
+++ b/.github/workflows/R-CMD-check-and-coverage.yaml
@@ -16,54 +16,29 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v4
-        with:
-          path: /usr/local/lib/R/site-library
-          key: ${{ runner.os }}-r-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-1-
-
-      - name: Setup R from r-lib
-        uses: r-lib/actions/setup-r@v2
-
-      - name: Install system dependencies from r-lib
+      - name: Install system dependencies & R deps
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: |
             any::rcmdcheck
             any::BiocCheck
             any::covr
+            any::sessioninfo
             local::.
-          needs: |
+          needs:
             coverage
             check
 
       - name: Install LaTeX
-        if: runner.os == 'Linux'
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y \
+          apt-get update -y
+          apt-get install -y \
             texlive-latex-base \
             texlive-fonts-recommended \
             texlive-fonts-extra
-
-      - name: Install dependencies
-        run: |
-          options(repos = c(CRAN = "https://cran.r-project.org"))
-          BiocManager::repositories()
-          remotes::install_deps(dependencies = TRUE, repos = BiocManager::repositories())
-          remotes::install_cran("covr")
-        shell: Rscript {0}
 
       - name: Session info
         run: |


### PR DESCRIPTION
Pr #176 did not completely fix the failing gha workflow. This pr (once again) updates R-CMD-check-and-coverage.yaml to make the gha run correctly, which can be seen in the forked repo's [action badge](https://github.com/AtaJadidAhari/ggbio/actions/runs/17830194410/job/50692927364).

p.s. I would recommend to use squash & merge option to add only one commit instead of three.


